### PR TITLE
Change path for project.clj to shared path that works for Lein 2.0.0-RC+

### DIFF
--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -52,10 +52,11 @@
                                                  :repositories repositories
                                                  :offline? offline?)))
         artifact-jar (:file (meta resolved-parent-artifact))
-        artifact-zip (ZipFile. artifact-jar)]
+        artifact-zip (ZipFile. artifact-jar)
+        project-clj-path (format "META-INF/leiningen/%s/project.clj" (first coords))]
     (project/init-project (project/read (InputStreamReader. (.getInputStream
                                           artifact-zip
-                                          (.getEntry artifact-zip "project.clj")))))))
+                                          (.getEntry artifact-zip project-clj-path)))))))
 
 (defn get-parent-project
   [project {:keys [path coords]}]

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -5,8 +5,7 @@
             [clojure.test :refer :all]
             [leiningen.core.project :as project]
             [leiningen.install :as install])
-  (:import (java.io FileNotFoundException)
-           (org.sonatype.aether.resolution DependencyResolutionException)))
+  (:import (java.io FileNotFoundException)))
 
 (def m {:a 1
         :b 2
@@ -68,8 +67,10 @@
     (let [project (read-child-project "with_parent_coords")]
       (is (= "foo" (:foo project)))))
   (testing "Error thrown if non-existent coords provided"
-    (is (thrown? DependencyResolutionException
-                 (read-child-project "with_invalid_parent_coords")))))
+    ;; To sidestep broken import statements around aether namespace change
+    ;; opting to evaluate the message.
+    (is (thrown-with-msg? Exception #"Could not find artifact lein-parent:does-not-exist"
+                         (read-child-project "with_invalid_parent_coords")))))
 
 (deftest inherited-values-test
   (testing "managed_dependencies can be inherited from parent"


### PR DESCRIPTION
NOTE: WIP PR before massaging this for a PR to the OS project.  Note I need to consult the contrib docs for formatting/commit messages, etc. but wanted to get this in front of some eyes before I further went down any path.

A change to Leiningen in 2.8.0-rc on, removed the project.clj from the root of the jar.  This meant that resolving a parents dependency tree was impossible as the project.clj file isn't found. From 2.0.0-RC on in Lein, this file is placed in META-INF. This PR uses the path for that project.clj file in the META-INF instead.

A second commit fixes a namespacing issue/Aether upgrade in Lein 2.8.0-rc on in test - where the DependencyResolutionException is differently imported for different version of Lein. I'm wondering if I should have done this differently? I checked the :cause / message, but wonder if instead I could convert the Exception type to a string? and just verify that it is DependencyResolutionException as a string matches.  Not sure it's possible, or potentially even grosser than the current string sniffing. But I can look into that.
 
For reference:
Aether upgrade/change in namespace on DependencyResolutionException
https://github.com/technomancy/leiningen/commit/c968fa5068fafadaca7eebf12391f691fcf2279d#diff-1b54638ff94371cd423868a08dfee7f8R12

Removal of project.clj from jar root
https://github.com/technomancy/leiningen/commit/3679ba26497f60f2a2c6465156ca232b6276c2bc